### PR TITLE
Validate Images using Metadata Endpoint

### DIFF
--- a/random_street_view.py
+++ b/random_street_view.py
@@ -5,6 +5,7 @@ import shapefile  # pip install pyshp
 import sys
 import urllib
 import getcolor
+import json
 
 # Optional, http://stackoverflow.com/a/1557906/724176
 try:
@@ -16,8 +17,10 @@ except:
 # Google Street View Image API
 # 25,000 image requests per 24 hours
 # See https://developers.google.com/maps/documentation/streetview/
-API_KEY = "INSERT_YOUR_API_KEY_HERE"
-GOOGLE_URL = ("http://maps.googleapis.com/maps/api/streetview?sensor=false&"
+API_KEY = "API KEY HERE"
+GOOGLE_IMG_URL = ("http://maps.googleapis.com/maps/api/streetview?sensor=false&"
+              "size=640x640&key=" + API_KEY)
+GOOGLE_METADATA_URL = ("https://maps.googleapis.com/maps/api/streetview/metadata?"
               "size=640x640&key=" + API_KEY)
 
 IMG_PREFIX = "img_"
@@ -83,32 +86,36 @@ for i, record in enumerate(sf.records()):
         break
 
 print "Getting images"
-attempts, country_hits, imagery_hits, imagery_misses = 0, 0, 0, 0
-MAX_URLS = 25000
+imagery_hits = 0
 
 if not os.path.exists(args.country):
     os.makedirs(args.country)
 
 try:
     while(True):
-        attempts += 1
         rand_lat = random.uniform(min_lat, max_lat)
         rand_lon = random.uniform(min_lon, max_lon)
-        # print attempts, rand_lat, rand_lon
-        # Is (lat,lon) inside borders?
         if point_inside_polygon(rand_lon, rand_lat, borders):
-            print "  In country"
-            country_hits += 1
             lat_lon = str(rand_lat) + "," + str(rand_lon)
             outfile = os.path.join(
                 args.country, IMG_PREFIX + lat_lon + IMG_SUFFIX)
-            url = GOOGLE_URL + "&location=" + lat_lon
+
+            meta_url = GOOGLE_METADATA_URL + "&location=" + lat_lon
+            img_url = GOOGLE_IMG_URL + "&location=" + lat_lon
             if args.heading:
-                url += "&heading=" + args.heading
+                img_url += "&heading=" + args.heading
+                meta_url += "&heading=" + args.heading
             if args.pitch:
-                url += "&pitch=" + args.pitch
+                img_url += "&pitch=" + args.pitch
+                meta_url += "&pitch=" + args.pitch
             try:
-                urllib.urlretrieve(url, outfile)
+                meta_res = urllib.urlopen(meta_url)
+                meta_body = meta_res.read()
+                meta_json = json.loads(meta_body.decode("utf-8"))
+                if 'status' in meta_json and meta_json['status'] == 'ZERO_RESULTS':
+                    pass
+                else:
+                    urllib.urlretrieve(img_url, outfile)
             except KeyboardInterrupt:
                 sys.exit("exit")
             except:
@@ -119,22 +126,15 @@ try:
                 color = getcolor.get_color(outfile)
                 print color
                 if color[0] == '#e3e2dd' or color[0] == "#e3e2de":
-                    print "    No imagery"
-                    imagery_misses += 1
                     os.remove(outfile)
                 else:
-                    print "    ========== Got one! =========="
+                    print "Got one!"
                     imagery_hits += 1
                     if imagery_hits == args.images_wanted:
                         break
-            if country_hits == MAX_URLS:
-                break
 except KeyboardInterrupt:
     print "Keyboard interrupt"
 
-print "Attempts:\t", attempts
-print "Country hits:\t", country_hits
-print "Imagery misses:\t", imagery_misses
-print "Imagery hits:\t", imagery_hits
+print "Downloaded:\t", imagery_hits
 
 # End of file


### PR DESCRIPTION
According to the [usage guidelines](https://developers.google.com/maps/documentation/streetview/usage-limits), Metadata requests for Google Street View do not count towards your quota.  Therefore, I modified the application to make requests to the metadata endpoint prior to making an image request.  This way, the maximum daily limit is 25,000 IMAGES rather than 25,000 REQUESTS.