### PR TITLE
Support pyshp 2, Python 3.7 and drop Python 2.7

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+extend-ignore = E203
+max-line-length = 88

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
- - "2.7"
  - "3.6"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,20 @@
 language: python
+cache: pip
+dist: xenial
 
 python:
  - "3.6"
+ - "3.7"
 
 install:
- - pip install pyflakes pycodestyle
- - pip install -r requirements.txt
+ - pip install --upgrade black
+ - pip install --upgrade flake8
+ - pip install --upgrade -r requirements.txt
 
 script:
  # Static analysis
- - pyflakes .
- - pycodestyle --statistics --count .
+ - flake8 --statistics --count
+ - black --check --diff --target-version py36 .
 
  # Dummy run
  - python random_street_view.py --help

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can see <a href="http://support.google.com/maps/bin/answer.py?hl=en&answer=6
 Prerequisites
 -------------
 
- * Python 2.7 or 3.6+
+ * Python 3.6+
  * Install Pillow and the Python Shapefile Library: `pip install pillow pyshp` or `pip install -r requirements.txt`
  * Get the World Borders Dataset (e.g. TM_WORLD_BORDERS-0.3.shp) from http://thematicmapping.org/downloads/world_borders.php
  * Get a Google API key from https://developers.google.com/maps/documentation/streetview/ and put it in the .py file. The API is limited to 25,000 Street View image requests per 24 hours. You can check how much you've used at the <a href="https://code.google.com/apis/console/">console</a>.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 random street view
-========
+==================
 
-Command-line Python script to get a number of Street View images from random locations in a given country.
+Command-line Python 3 script to get a number of Street View images from random locations in a given country.
 
 Random (lat, lon) co-ordinates are generated from the country's border's bounding box, then checked to make sure they're within the actual borders. The corresponding Street View image downloaded. Often there is no imagery for the location, so if the size of the image matches that of the default "no imagery" thumbnail, it's deleted. Repeat until required number of images have been fetched.
 
@@ -11,7 +11,7 @@ Prerequisites
 -------------
 
  * Python 3.6+
- * Install Pillow and the Python Shapefile Library: `pip install pillow pyshp` or `pip install -r requirements.txt`
+ * Install Pillow and the Python Shapefile Library: `pip install pillow "pyshp>=2"` or `pip install -r requirements.txt`
  * Get the World Borders Dataset (e.g. TM_WORLD_BORDERS-0.3.shp) from http://thematicmapping.org/downloads/world_borders.php
  * Get a Google API key from https://developers.google.com/maps/documentation/streetview/ and put it in the .py file. The API is limited to 25,000 Street View image requests per 24 hours. You can check how much you've used at the <a href="https://code.google.com/apis/console/">console</a>.
 

--- a/getcolor.py
+++ b/getcolor.py
@@ -1,7 +1,7 @@
 # http://charlesleifer.com/blog/using-python-and-k-means-to-find-the-dominant-colors-in-images/
+import random
 from collections import namedtuple
 from math import sqrt
-import random
 
 from PIL import Image  # pip install pillow
 

--- a/getcolor.py
+++ b/getcolor.py
@@ -5,8 +5,8 @@ from math import sqrt
 
 from PIL import Image  # pip install pillow
 
-Point = namedtuple('Point', ('coords', 'n', 'ct'))
-Cluster = namedtuple('Cluster', ('points', 'center', 'n'))
+Point = namedtuple("Point", ("coords", "n", "ct"))
+Cluster = namedtuple("Cluster", ("points", "center", "n"))
 
 
 def get_points(img):
@@ -18,7 +18,7 @@ def get_points(img):
 
 
 def rtoh(rgb):
-    return '#%s' % ''.join(('%02x' % p for p in rgb))
+    return "#%s" % "".join(("%02x" % p for p in rgb))
 
 
 def get_color(image, n=1):
@@ -42,7 +42,7 @@ def calculate_center(points, n):
     for p in points:
         plen += p.ct
         for i in range(n):
-            vals[i] += (p.coords[i] * p.ct)
+            vals[i] += p.coords[i] * p.ct
     return Point([(v / plen) for v in vals], n, 1)
 
 
@@ -53,7 +53,7 @@ def kmeans(points, k, min_diff):
         plists = [[] for i in range(k)]
 
         for p in points:
-            smallest_distance = float('Inf')
+            smallest_distance = float("Inf")
             for i in range(k):
                 distance = euclidean(p, clusters[i].center)
                 if distance < smallest_distance:

--- a/getcolor.py
+++ b/getcolor.py
@@ -18,13 +18,12 @@ def get_points(img):
 
 
 def rtoh(rgb):
-    return "#%s" % "".join(("%02x" % p for p in rgb))
+    return "#%s" % "".join("%02x" % p for p in rgb)
 
 
 def get_color(image, n=1):
     img = Image.open(image)
     img.thumbnail((200, 200))
-    w, h = img.size
 
     points = get_points(img)
     clusters = kmeans(points, n, 1)

--- a/random_street_view.py
+++ b/random_street_view.py
@@ -11,7 +11,8 @@ import getcolor
 # Optional, http://stackoverflow.com/a/1557906/724176
 try:
     import timing
-    assert(timing)  # avoid flake8 warning
+
+    assert timing  # avoid flake8 warning
 except ImportError:
     pass
 
@@ -19,26 +20,32 @@ except ImportError:
 # 25,000 image requests per 24 hours
 # See https://developers.google.com/maps/documentation/streetview/
 API_KEY = "INSERT_YOUR_API_KEY_HERE"
-GOOGLE_URL = ("http://maps.googleapis.com/maps/api/streetview?sensor=false&"
-              "size=640x640&key=" + API_KEY)
+GOOGLE_URL = (
+    "http://maps.googleapis.com/maps/api/streetview?sensor=false&"
+    "size=640x640&key=" + API_KEY
+)
 
 IMG_PREFIX = "img_"
 IMG_SUFFIX = ".jpg"
 
 parser = argparse.ArgumentParser(
     description="Get random Street View images from a given country",
-    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+)
 parser.add_argument(
-    '-n', '--images-wanted', type=int,
-    default=10,
-    help="Number of images wanted")
-parser.add_argument('country',  help='ISO 3166-1 Alpha-3 Country Code')
+    "-n", "--images-wanted", type=int, default=10, help="Number of images wanted"
+)
+parser.add_argument("country", help="ISO 3166-1 Alpha-3 Country Code")
 parser.add_argument(
-    '-hdg', '--heading',
-    help="Heading in degrees: 0 and 360 north, 90 east, 180 south, 270 west")
+    "-hdg",
+    "--heading",
+    help="Heading in degrees: 0 and 360 north, 90 east, 180 south, 270 west",
+)
 parser.add_argument(
-    '-p', '--pitch',
-    help="Pitch in degrees: 0 is default, 90 straight up, -90 straight down")
+    "-p",
+    "--pitch",
+    help="Pitch in degrees: 0 is default, 90 straight up, -90 straight down",
+)
 args = parser.parse_args()
 
 
@@ -49,13 +56,13 @@ def point_inside_polygon(x, y, poly):
     n = len(poly)
     inside = False
     p1x, p1y = poly[0]
-    for i in range(n+1):
+    for i in range(n + 1):
         p2x, p2y = poly[i % n]
         if y > min(p1y, p2y):
             if y <= max(p1y, p2y):
                 if x <= max(p1x, p2x):
                     if p1y != p2y:
-                        xinters = (y-p1y)*(p2x-p1x)/(p2y-p1y)+p1x
+                        xinters = (y - p1y) * (p2x - p1x) / (p2y - p1y) + p1x
                     if p1x == p2x or x <= xinters:
                         inside = not inside
         p1x, p1y = p2x, p2y
@@ -65,9 +72,10 @@ def point_inside_polygon(x, y, poly):
 print("Loading borders")
 shape_file = "TM_WORLD_BORDERS-0.3.shp"
 if not os.path.exists(shape_file):
-    print("Cannot find " + shape_file + ". Please download it from "
-          "http://thematicmapping.org/downloads/world_borders.php "
-          "and try again.")
+    print(
+        "Cannot find " + shape_file + ". Please download it from "
+        "http://thematicmapping.org/downloads/world_borders.php and try again."
+    )
     sys.exit()
 
 sf = shapefile.Reader(shape_file)
@@ -93,7 +101,7 @@ if not os.path.exists(args.country):
     os.makedirs(args.country)
 
 try:
-    while(True):
+    while True:
         attempts += 1
         rand_lat = random.uniform(min_lat, max_lat)
         rand_lon = random.uniform(min_lon, max_lon)
@@ -103,8 +111,7 @@ try:
             print("  In country")
             country_hits += 1
             lat_lon = str(rand_lat) + "," + str(rand_lon)
-            outfile = os.path.join(
-                args.country, IMG_PREFIX + lat_lon + IMG_SUFFIX)
+            outfile = os.path.join(args.country, IMG_PREFIX + lat_lon + IMG_SUFFIX)
             url = GOOGLE_URL + "&location=" + lat_lon
             if args.heading:
                 url += "&heading=" + args.heading
@@ -119,7 +126,7 @@ try:
                 # get_color returns the main color of image
                 color = getcolor.get_color(outfile)
                 print(color)
-                if color[0] == '#e3e2dd' or color[0] == "#e3e2de":
+                if color[0] == "#e3e2dd" or color[0] == "#e3e2de":
                     print("    No imagery")
                     imagery_misses += 1
                     os.remove(outfile)

--- a/random_street_view.py
+++ b/random_street_view.py
@@ -78,7 +78,7 @@ if not os.path.exists(shape_file):
     )
     sys.exit()
 
-sf = shapefile.Reader(shape_file)
+sf = shapefile.Reader(shape_file, encoding="latin1")
 shapes = sf.shapes()
 
 print("Finding country")

--- a/random_street_view.py
+++ b/random_street_view.py
@@ -1,21 +1,12 @@
-from __future__ import print_function, unicode_literals
-
 import argparse
 import os
 import random
 import sys
+from urllib.request import urlretrieve
 
 import shapefile  # pip install pyshp
 
 import getcolor
-
-try:
-    # Python 3
-    from urllib.request import urlretrieve
-except ImportError:
-    # Python 2
-    from urllib import urlretrieve
-
 
 # Optional, http://stackoverflow.com/a/1557906/724176
 try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Pillow
-pyshp
+pyshp>=2


### PR DESCRIPTION
Fixes #9.

* Add shapefile encoding to support pyshp 2
* Drop support for legacy Python 2.7
* Add support for Python 3.7
* Test Flake8 and Black and on CI
* Format with Black
